### PR TITLE
Build dist folder upon npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "babel src --out-dir dist --ignore '*.test.js'",
     "test": "jest src",
     "prettier": "prettier --write 'src/**/*.js'",
-    "flow": "flow src"
+    "flow": "flow src",
+    "prepare": "yarn build"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
Hello,

Thanks for this great utility lib.

The dist folder is not built when this package is published to npm. On the current published version (1.1.0), there is **no** `dist` folder, which makes the package impossible to use.