### PR TITLE
Fix onClose

### DIFF
--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -145,6 +145,24 @@ describe('options', () => {
     await iter.return();
   });
 
+  it('should call onClose with the return value from an listener only after the promise resolves', async () => {
+    const returnValue = 'asdf';
+    const listener = (cb: () => void) =>
+      new Promise(res => {
+        res(returnValue);
+      });
+
+    expect.hasAssertions();
+    const iter = asyncify(listener, {
+      onClose: val => {
+        expect(val).toEqual(returnValue);
+      },
+    });
+    // Wait a tick so that the promise resolves with the return value
+    iter.return();
+    await new Promise(res => setTimeout(res, 10));
+  });
+
   describe('buffering', () => {
     it('should not buffer incoming values if disabled', async () => {
       const listener = (cb: (arg: number) => void) =>

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -95,6 +95,38 @@ describe('options', () => {
     });
   });
 
+  it('should call onError with an error thrown by a non async onClose', async () => {
+    const error = new Error('Bla bla');
+    const listener = (cb: () => void) => Promise.resolve();
+
+    expect.assertions(1);
+    const iter = asyncify(listener, {
+      onClose: () => {
+        throw error;
+      },
+      onError: err => {
+        expect(err).toEqual(error);
+      },
+    });
+    await iter.return();
+  });
+
+  it('should call onError with an error thrown by an async onClose', async () => {
+    const error = new Error('Bla bla');
+    const listener = (cb: () => void) => Promise.resolve();
+
+    expect.assertions(1);
+    const iter = asyncify(listener, {
+      onClose: async () => {
+        throw error;
+      },
+      onError: err => {
+        expect(err).toEqual(error);
+      },
+    });
+    await iter.return();
+  });
+
   it('should call onClose with the return value from the listener', async () => {
     const returnValue = 'asdf';
     const listener = (cb: () => void) =>


### PR DESCRIPTION
Currently, onClose can get called before the listener is able to produce a value. Also, any error raised in onClose is swallowed if the onClose function is a promise. This merge request attempts to resolve both of those issues.